### PR TITLE
Set update-on-launch to true by default on projects

### DIFF
--- a/roles/confirm-tower-project/tasks/main.yml
+++ b/roles/confirm-tower-project/tasks/main.yml
@@ -8,9 +8,8 @@
     scm_type:                   "{{ job_vars['__meta__']['deployer']['scm_type'] }}"
     scm_url:                    "{{ job_vars['__meta__']['deployer']['scm_url'] }}"
     scm_branch:                 "{{ job_vars['__meta__']['deployer']['scm_ref'] }}"
-    # Update the project when the ref is not a versioned tag.
-    scm_update_on_launch: >-
-      {{ job_vars['__meta__']['deployer']['scm_ref'] is not search('\d\.\d') }}
+    # Always update on launch because even tags can change between provision and destroy
+    scm_update_on_launch: true
     scm_update_cache_timeout:   "{{ babylon_scm_update_cache_timeout }}"
   register: r_tower_project
 


### PR DESCRIPTION
Sometimes the tag changes between provision and destroy and produces the
following error in job_runner:

```
TASK [confirm-tower-job-template : Patch or Create Tower Job Template provision-agnosticd-rhs-2020-t1a3f9-dev-0.1-7l6bd] ***
08:56:56

Thursday 02 April 2020  06:56:56 +0000 (0:00:00.592)       0:00:02.982 ********

fatal: [localhost]: FAILED! => {"allow": "GET, POST, HEAD, OPTIONS", "changed": false, "connection": "close", "content": "{\"playbook\":[\"Playbook not found for project.\"]}", "content_language": "en", "content_length": "48", "content_type": "application/json", "date": "Thu, 02 Apr 2020 06:56:56 GMT", "elapsed": 0, "json": {"playbook": ["Playbook not found for project."]}, "msg": "Status code was 400 and not [200, 201]: HTTP Error 400: Bad Request", "redirected": false, "server": "nginx", "status": 400, "url": "https://localhost/api/v2/job_templates/", "vary": "Accept, Accept-Language, Origin, Cookie", "x_api_node": "tower1.dt-rhsummit-dev.internal", "x_api_time": "0.147s", "x_api_total_time": "0.175s"}
```

Setting the update_on_launch to fix this issue.