### PR TITLE
Retry on confirm-tower-project

### DIFF
--- a/roles/confirm-tower-job-template/tasks/main.yml
+++ b/roles/confirm-tower-job-template/tasks/main.yml
@@ -46,4 +46,8 @@
         | combine({'output_dir': '/tmp/' ~ job_template_name ~ '.' ~ random_string})
         ) | to_json }}
     random_string: "{{ lookup('password', '/dev/null chars=ascii_letters,digits length=8') }}"
+  register: r_patch_or_create_tower_job
+  until: r_patch_or_create_tower_job.status in [200, 201]
+  retries: 3
+  delay: 30
 ...

--- a/roles/confirm-tower-project/tasks/main.yml
+++ b/roles/confirm-tower-project/tasks/main.yml
@@ -8,8 +8,9 @@
     scm_type:                   "{{ job_vars['__meta__']['deployer']['scm_type'] }}"
     scm_url:                    "{{ job_vars['__meta__']['deployer']['scm_url'] }}"
     scm_branch:                 "{{ job_vars['__meta__']['deployer']['scm_ref'] }}"
-    # Always update on launch because even tags can change between provision and destroy
-    scm_update_on_launch: true
+    # Update the project when the ref is not a versioned tag.
+    scm_update_on_launch: >-
+      {{ job_vars['__meta__']['deployer']['scm_ref'] is not search('\d\.\d') }}
     scm_update_cache_timeout:   "{{ babylon_scm_update_cache_timeout }}"
   register: r_tower_project
 


### PR DESCRIPTION
Sometimes on freshly created projects the job runner will try to create a job template before SCM sync has completed.

This PR restores the version tag based auto-update on projects and adds retries on template creation.